### PR TITLE
Replace login and register links on restricted

### DIFF
--- a/add.html
+++ b/add.html
@@ -37,11 +37,9 @@
                          <li class="hidden">
                              <a href="#page-top"></a>
                          </li>
+                         <p class="navbar-text">Signed in as <a href="#" class="navbar-link">Mark Otto</a></p>
                          <li>
-                             <a href="./login.html">Login</a>
-                         </li>
-                         <li>
-                             <a href="./register.html">Register</a>
+                             <a href="#logout">Logout</a>
                          </li>
                      </ul>
                  </div>

--- a/search.html
+++ b/search.html
@@ -37,11 +37,9 @@
                          <li class="hidden">
                              <a href="#page-top"></a>
                          </li>
+                         <p class="navbar-text">Signed in as <a href="#" class="navbar-link">Mark Otto</a></p>
                          <li>
-                             <a href="./login.html">Login</a>
-                         </li>
-                         <li>
-                             <a href="./register.html">Register</a>
+                            <a href="#logout">Logout</a>
                          </li>
                      </ul>
                  </div>


### PR DESCRIPTION
Sites that are restricted via login should not display login and
registration links, instead use the space to display the account that is
logged in and a logout link.

Resolves #14
